### PR TITLE
MULE-11982: Boot packages needs to be removed and modules must explic…

### DIFF
--- a/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
@@ -19,6 +19,7 @@ import static org.mule.functional.junit4.rules.ExpectedError.none;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.functional.junit4.rules.ExpectedError;
 import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
@@ -26,6 +27,7 @@ import com.icegreen.greenmail.util.ServerSetup;
 
 import org.junit.Rule;
 
+@ArtifactClassLoaderRunnerConfig(sharedRuntimeLibs = {"com.sun.mail:javax.mail"})
 public abstract class EmailConnectorTestCase extends MuleArtifactFunctionalTestCase {
 
   protected static final String NAMESPACE = "EMAIL";


### PR DESCRIPTION
…itly define what they export

_ Sharing javax.mail to let test create Multipart instances (has to be the same class as the one used on the plugin because test use an embedded email server)