### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extension/email/api/attributes/BaseEmailAttributes.java
+++ b/src/main/java/org/mule/extension/email/api/attributes/BaseEmailAttributes.java
@@ -12,7 +12,7 @@ import static java.util.Collections.list;
 import static javax.mail.Message.RecipientType.BCC;
 import static javax.mail.Message.RecipientType.CC;
 import static javax.mail.Message.RecipientType.TO;
-import static org.mule.runtime.core.util.collection.Collectors.toImmutableList;
+import static org.mule.runtime.core.api.util.collection.Collectors.toImmutableList;
 import org.mule.extension.email.api.exception.CannotFetchMetadataException;
 import org.mule.extension.email.internal.commands.PagingProviderEmailDelegate;
 import org.mule.runtime.core.message.BaseAttributes;


### PR DESCRIPTION
_ Moving classes to api/internal packages
_ Removing unused code