### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extension/email/api/attributes/BaseEmailAttributes.java
+++ b/src/main/java/org/mule/extension/email/api/attributes/BaseEmailAttributes.java
@@ -15,7 +15,7 @@ import static javax.mail.Message.RecipientType.TO;
 import static org.mule.runtime.core.api.util.collection.Collectors.toImmutableList;
 import org.mule.extension.email.api.exception.CannotFetchMetadataException;
 import org.mule.extension.email.internal.commands.PagingProviderEmailDelegate;
-import org.mule.runtime.core.message.BaseAttributes;
+import org.mule.runtime.core.api.message.BaseAttributes;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/main/java/org/mule/extension/email/internal/commands/PagingProviderEmailDelegate.java
+++ b/src/main/java/org/mule/extension/email/internal/commands/PagingProviderEmailDelegate.java
@@ -13,7 +13,7 @@ import static javax.mail.Folder.READ_WRITE;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.mule.extension.email.internal.util.EmailConnectorConstants.CONTENT_TYPE_HEADER;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
-import static org.mule.runtime.core.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
+import static org.mule.runtime.core.api.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
 import org.mule.extension.email.api.attributes.BaseEmailAttributes;
 import org.mule.extension.email.api.exception.CannotFetchMetadataException;
 import org.mule.extension.email.api.exception.EmailException;
@@ -23,7 +23,7 @@ import org.mule.extension.email.internal.mailbox.MailboxConnection;
 import org.mule.extension.email.internal.util.EmailContentProcessor;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;
-import org.mule.runtime.core.message.DefaultMultiPartPayload;
+import org.mule.runtime.core.api.message.DefaultMultiPartPayload;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.streaming.PagingProvider;
 

--- a/src/main/java/org/mule/extension/email/internal/util/EmailContentProcessor.java
+++ b/src/main/java/org/mule/extension/email/internal/util/EmailContentProcessor.java
@@ -12,7 +12,7 @@ import static org.mule.extension.email.internal.util.EmailConnectorConstants.TEX
 import org.mule.extension.email.api.exception.EmailException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;
-import org.mule.runtime.core.message.PartAttributes;
+import org.mule.runtime.core.api.message.PartAttributes;
 import org.mule.runtime.core.api.util.IOUtils;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mule/extension/email/retriever/AbstractEmailRetrieverTestCase.java
+++ b/src/test/java/org/mule/extension/email/retriever/AbstractEmailRetrieverTestCase.java
@@ -37,7 +37,7 @@ import org.mule.runtime.api.message.MultiPartPayload;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
-import org.mule.runtime.core.message.DefaultMultiPartPayload;
+import org.mule.runtime.core.api.message.DefaultMultiPartPayload;
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import org.junit.Before;

--- a/src/test/java/org/mule/extension/email/util/EmailTestUtils.java
+++ b/src/test/java/org/mule/extension/email/util/EmailTestUtils.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.message.MultiPartPayload;
-import org.mule.runtime.core.message.DefaultMultiPartPayload;
+import org.mule.runtime.core.api.message.DefaultMultiPartPayload;
 
 import com.icegreen.greenmail.util.ServerSetup;
 


### PR DESCRIPTION
_ Moving more classes from org.mule.runtime.core.message to api/internal