### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/src/main/java/org/mule/extension/email/internal/sender/SendOperation.java
+++ b/src/main/java/org/mule/extension/email/internal/sender/SendOperation.java
@@ -17,7 +17,7 @@ import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.TransformationService;
 import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.api.transformer.TransformerException;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.runtime.extension.api.annotation.error.Throws;
 import org.mule.runtime.extension.api.annotation.param.Config;
 import org.mule.runtime.extension.api.annotation.param.Connection;


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element