### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
@@ -36,7 +36,7 @@ import com.icegreen.greenmail.util.ServerSetup;
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 
-@ArtifactClassLoaderRunnerConfig(sharedRuntimeLibs = {"com.sun.mail:javax.mail", "org.mule.tests:mule-tests-unit"},
+@ArtifactClassLoaderRunnerConfig(applicationSharedRuntimeLibs = {"com.sun.mail:javax.mail"},
     exportPluginClasses = EmailError.class)
 public abstract class EmailConnectorTestCase extends MuleArtifactFunctionalTestCase {
 


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts