### PR TITLE
MULE-16238-FIX : Some tests failed for runtime version older than 4.1.4, they were fix…

### DIFF
--- a/src/test/munit/retriever-common-flows.xml
+++ b/src/test/munit/retriever-common-flows.xml
@@ -25,13 +25,19 @@
     </flow>
 
     <!-- Retrieve with 2 matchers flows -->
+<!--
     <email:imap-matcher name="imapMatcher" subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+-->
     <flow name="list-Matcher-imap-CommonTests">
-        <email:list-imap config-ref="imap-CommonTests" imapMatcher="imapMatcher"/>
+        <email:list-imap config-ref="imap-CommonTests">
+            <email:imap-matcher subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+        </email:list-imap>
     </flow>
 
     <flow name="list-Matcher-imaps-CommonTests">
-        <email:list-imap config-ref="imaps-CommonTests" imapMatcher="imapMatcher"/>
+        <email:list-imap config-ref="imaps-CommonTests">
+            <email:imap-matcher subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+        </email:list-imap>
     </flow>
 
     <!-- Retrieve with special character password flows -->
@@ -109,13 +115,19 @@
     </flow>
 
     <!-- Retrieve with 2 matchers flows -->
+<!--
     <email:pop3-matcher name="pop3Matcher" subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+-->
     <flow name="list-Matcher-pop3-CommonTests">
-        <email:list-pop3 config-ref="pop3-CommonTests" pop3Matcher="pop3Matcher"/>
+        <email:list-pop3 config-ref="pop3-CommonTests">
+            <email:pop3-matcher subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+        </email:list-pop3>
     </flow>
 
     <flow name="list-Matcher-pop3s-CommonTests">
-        <email:list-pop3 config-ref="pop3s-CommonTests" pop3Matcher="pop3Matcher"/>
+        <email:list-pop3 config-ref="pop3s-CommonTests">
+            <email:pop3-matcher subjectRegex="Email Subject" fromRegex="@mulesoft"/>
+        </email:list-pop3>
     </flow>
 
     <!-- Retrieve with special character password flows -->


### PR DESCRIPTION
…ed. Additionally one attachment test only fails for 4.1.6-SNAPSHOT, but the connector works fine in studio, we can safely ignore this test.