### PR TITLE
MULE-17052: Update java mail to jakarta 1.6.3, java activation to jak…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.mule.extensions</groupId>
         <artifactId>mule-core-modules-parent</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.5</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -22,8 +22,8 @@
         <commonsIoVersion>2.6</commonsIoVersion>
         <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
         <commonsLangVersion>3.7</commonsLangVersion>
-        <javaMailVersion>1.6.2</javaMailVersion>
-        <javaActivationVersion>1.2.0</javaActivationVersion>
+        <javaMailVersion>1.6.3</javaMailVersion>
+        <javaActivationVersion>1.2.1</javaActivationVersion>
         <greenmailVersion>1.5.0</greenmailVersion>
         <powermockVersion>2.0.0</powermockVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
@@ -109,7 +109,7 @@
                     </dependency>
                     <dependency>
                         <groupId>com.sun.mail</groupId>
-                        <artifactId>javax.mail</artifactId>
+                        <artifactId>jakarta.mail</artifactId>
                         <version>${javaMailVersion}</version>
                     </dependency>
                 </dependencies>
@@ -120,12 +120,12 @@
     <dependencies>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
             <version>${javaMailVersion}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>
-            <artifactId>javax.activation</artifactId>
+            <artifactId>jakarta.activation</artifactId>
             <version>${javaActivationVersion}</version>
         </dependency>
         <dependency>
@@ -193,12 +193,6 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>javax.activation</artifactId>
-            <version>${javaActivationVersion}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/email/EmailConnectorTestCase.java
@@ -37,7 +37,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 
 @ArtifactClassLoaderRunnerConfig(
-    applicationSharedRuntimeLibs = "com.sun.mail:javax.mail",
+    applicationSharedRuntimeLibs = "com.sun.mail:jakarta.mail",
     testExclusions = {"org.mule.module:mule-java-module"},
     exportPluginClasses = EmailError.class)
 public abstract class EmailConnectorTestCase extends MuleArtifactFunctionalTestCase {


### PR DESCRIPTION
…arta 1.2.1 and parent version to 1.1.5 to be sure that the only transitive dep is javax.activation 1.2.1