### PR TITLE
Chore/release 1.4.1

### DIFF
--- a/formatter.xml
+++ b/formatter.xml
@@ -20,6 +20,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-email-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
 
     <name>Email Connector</name>
     <description>A Mule extension that provides functionality to send and receive emails through POP3, IMAP and SMTP</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.1.0</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
         <munit.version>2.3.2</munit.version>
         <mtf.tools.version>1.1.0</mtf.tools.version>
         <mavenResourcesVersion>3.2.0</mavenResourcesVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <commonsIoVersion>2.8.0</commonsIoVersion>
         <commonsLangVersion>3.11</commonsLangVersion>
-        <jakartaMailVersion>1.6.3</jakartaMailVersion>
+        <jakartaMailVersion>1.6.6</jakartaMailVersion>
         <jakartaActivationVersion>2.0.0</jakartaActivationVersion>
         <greenmailVersion>1.5.10</greenmailVersion>
         <powermockVersion>2.0.9</powermockVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
         <munit.extensions.maven.plugin.version>1.1.0</munit.extensions.maven.plugin.version>
         <munit.version>2.3.2</munit.version>
-        <mtf.tools.version>1.0.0</mtf.tools.version>
+        <mtf.tools.version>1.1.0</mtf.tools.version>
         <mavenResourcesVersion>3.2.0</mavenResourcesVersion>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <validations.module.version>1.4.3</validations.module.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <javaXmlBindVersion>3.0.0</javaXmlBindVersion>
         <istackCommonsRuntimeVersion>4.0.0</istackCommonsRuntimeVersion>
 
-        <validations.module.version>1.4.2</validations.module.version>
+        <validations.module.version>1.4.3</validations.module.version>
         <java.module.version>1.2.7</java.module.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <commonsIoVersion>2.8.0</commonsIoVersion>
-        <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
         <commonsLangVersion>3.11</commonsLangVersion>
         <javaMailVersion>1.6.3</javaMailVersion>
         <javaActivationVersion>2.0.0</javaActivationVersion>
@@ -35,12 +34,7 @@
         <munit.version>2.3.2</munit.version>
         <mtf.tools.version>1.0.0</mtf.tools.version>
         <mavenResourcesVersion>3.2.0</mavenResourcesVersion>
-
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
-        <javaXmlBindApiVersion>2.3.1</javaXmlBindApiVersion>
-        <javaXmlBindVersion>3.0.0</javaXmlBindVersion>
-        <istackCommonsRuntimeVersion>4.0.0</istackCommonsRuntimeVersion>
-
         <validations.module.version>1.4.3</validations.module.version>
         <java.module.version>1.2.7</java.module.version>
     </properties>
@@ -129,38 +123,18 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
             <version>${javaMailVersion}</version>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.sun.activation</groupId>
+            		<artifactId>jakarta.activation</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>${javaActivationVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${javaXmlBindApiVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${javaXmlBindVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.xml.stream</groupId>
-                    <artifactId>stax-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-            <version>${istackCommonsRuntimeVersion}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>${commonsCollectionsVersion}</version>
+            <version>1.2.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -173,21 +147,6 @@
             <version>${commonsIoVersion}</version>
         </dependency>
 
-        <!--TODO: MULE-10837-->
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-service</artifactId>
-            <version>${mule.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.services</groupId>
-            <artifactId>mule-service-scheduler</artifactId>
-            <version>${muleSchedulerServiceVersion}</version>
-            <classifier>mule-service</classifier>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.icegreen</groupId>
@@ -198,6 +157,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>javax.activation</groupId>
+                	<artifactId>activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <properties>
         <commonsIoVersion>2.8.0</commonsIoVersion>
         <commonsLangVersion>3.11</commonsLangVersion>
-        <javaMailVersion>1.6.3</javaMailVersion>
-        <javaActivationVersion>2.0.0</javaActivationVersion>
+        <jakartaMailVersion>1.6.3</jakartaMailVersion>
+        <jakartaActivationVersion>2.0.0</jakartaActivationVersion>
         <greenmailVersion>1.5.10</greenmailVersion>
         <powermockVersion>2.0.9</powermockVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
@@ -111,7 +111,7 @@
                     <dependency>
                         <groupId>com.sun.mail</groupId>
                         <artifactId>jakarta.mail</artifactId>
-                        <version>${javaMailVersion}</version>
+                        <version>${jakartaMailVersion}</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <version>${javaMailVersion}</version>
+            <version>${jakartaMailVersion}</version>
             <exclusions>
             	<exclusion>
             		<groupId>com.sun.activation</groupId>
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>2.0.0</version>
+            <version>${jakartaActivationVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-email-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 
     <name>Email Connector</name>
     <description>A Mule extension that provides functionality to send and receive emails through POP3, IMAP and SMTP</description>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>1.2.1</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-email-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <name>Email Connector</name>
     <description>A Mule extension that provides functionality to send and receive emails through POP3, IMAP and SMTP</description>

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,5 @@
 {
   "extends": [
     "config:base"
-  ],
-  "branchPrefix": "renovate-",
-  "prHourlyLimit": 1,
-  "prConcurrentLimit": 10,
-  "schedule": [
-    "after 8pm and before 8am on every weekday",
-    "every weekend"
-  ],
-  "timezone": "America/Argentina/Buenos_Aires",
-  "ignoreDeps": [
-    "org.mule.extensions:mule-core-modules-parent"
   ]
 }

--- a/src/main/java/org/mule/extension/email/internal/StoredEmailContentFactory.java
+++ b/src/main/java/org/mule/extension/email/internal/StoredEmailContentFactory.java
@@ -26,6 +26,7 @@ import org.mule.runtime.extension.api.runtime.streaming.StreamingHelper;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -139,11 +140,14 @@ public class StoredEmailContentFactory {
    * @return the attachment's content as a {@link TypedValue}.
    */
   private TypedValue<InputStream> resolveContent(Part part, StreamingHelper streamingHelper) {
+    Object content = null;
     try {
       InputStream partContent = contentResolver.resolveInputStream(part);
-      Object content = streamingHelper != null ? streamingHelper.resolveCursorProvider(partContent) : partContent;
+      content = streamingHelper != null ? streamingHelper.resolveCursorProvider(partContent) : partContent;
       DataType dataType = builder().type(content.getClass()).mediaType(part.getContentType()).build();
       return new TypedValue(content, dataType);
+    } catch (UnsupportedCharsetException e) {
+      return new TypedValue(content, DataType.OBJECT);
     } catch (MessagingException | IOException e) {
       throw new EmailException("Could not resolve the attachment", e);
     }

--- a/src/test/java/org/mule/extension/email/EmailContentProcessorTestCase.java
+++ b/src/test/java/org/mule/extension/email/EmailContentProcessorTestCase.java
@@ -26,6 +26,8 @@ import static org.mule.extension.email.util.EmailTestUtils.EMAIL_SUBJECT;
 import static org.mule.extension.email.util.EmailTestUtils.EMAIL_TEXT_PLAIN_ANOTHER_ATTACHMENT_CONTENT;
 import static org.mule.extension.email.util.EmailTestUtils.EMAIL_TEXT_PLAIN_ATTACHMENT_CONTENT;
 import static org.mule.extension.email.util.EmailTestUtils.EMAIL_TEXT_PLAIN_ATTACHMENT_NAME;
+import static org.mule.extension.email.util.EmailTestUtils.EMAIL_BASE_64_ATTACHMENT_NAME;
+import static org.mule.extension.email.util.EmailTestUtils.EMAIL_BASE_64_ATTACHMENT_CONTENT;
 import static org.mule.extension.email.util.EmailTestUtils.getAlternativeRelatedTestMessage;
 import static org.mule.extension.email.util.EmailTestUtils.getAlternativeTestMessage;
 import static org.mule.extension.email.util.EmailTestUtils.getBadBodyEmail;
@@ -40,6 +42,7 @@ import static org.mule.extension.email.util.EmailTestUtils.getMixedTestMessageWi
 import static org.mule.extension.email.util.EmailTestUtils.getRelatedTestMessage;
 import static org.mule.extension.email.util.EmailTestUtils.getSimpleHTMLTestMessage;
 import static org.mule.extension.email.util.EmailTestUtils.getSimpleTextTestMessage;
+import static org.mule.extension.email.util.EmailTestUtils.getMixedRelatedAlternativeCharsetBinaryTestMessage;
 
 import org.mule.extension.email.api.StoredEmailContent;
 import org.mule.extension.email.internal.StoredEmailContentFactory;
@@ -261,6 +264,14 @@ public class EmailContentProcessorTestCase extends AbstractMuleTestCase {
     assertThat(attachments.entrySet(), hasSize(2));
     assertAttachmentContent(attachments, EMAIL_TEXT_PLAIN_ATTACHMENT_NAME, EMAIL_TEXT_PLAIN_ATTACHMENT_CONTENT);
     assertAttachmentContent(attachments, EMAIL_JSON_ATTACHMENT_NAME, EMAIL_JSON_ATTACHMENT_CONTENT);
+  }
+
+  @Test
+  public void attachmentsFromMixedMailWithUnsupportedCharset() throws Exception {
+    javax.mail.Message message = getMixedRelatedAlternativeCharsetBinaryTestMessage();
+    Map<String, TypedValue<InputStream>> attachments = contentFactory.fromMessage(message, NAME).getAttachments();
+    assertThat(attachments.entrySet(), hasSize(2));
+    assertAttachmentContent(attachments, EMAIL_BASE_64_ATTACHMENT_NAME, EMAIL_BASE_64_ATTACHMENT_CONTENT);
   }
 
   private void assertAttachmentContent(Map<String, TypedValue<InputStream>> attachments, String name, String expected)


### PR DESCRIPTION
== 1.4.1

*March 26, 2021*

=== Fixed Issues

The Email Connector now treats attachments for which it cannot recognise their type as objects. (https://www.mulesoft.org/jira/browse/EMAILC-61[EMAILC-61])
