### PR TITLE
EMAILC-67: Release version 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-email-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
 
     <name>Email Connector</name>
     <description>A Mule extension that provides functionality to send and receive emails through POP3, IMAP and SMTP</description>


### PR DESCRIPTION
## 1.5.0

* Added a new system property called `parsing.text.attachment.as.body` that enables you to change the behavior for parsing attached text files when the file is the only content in the message. The possible values are:  
** `true` (default): Preserves the previous behavior and converts the text file attachment on the body message.
** `false`: Adds the text file attachment to the attachment list in the payload.

### Fixed
* Incomplete attachment parsing over non-multipart messages, for example, some messages had no body and only contained an attachment file.  EMAILC-67
* The number of emails retrieved didn’t match the configured value page size and limit.  EMAILC-68